### PR TITLE
Revised nfx3 parsing with additional extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ authors = ["Mark King <mark.king@markzz.com>"]
 [dependencies]
 byteorder = "1.5.0"
 bzip2 = "0.4.4"
+eui48 = "1.1.0"
 lz4_flex = "0.11.1"
 minilzo = "0.2.0"
 zstd = "0.13.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod nffilev1;
 mod nffilev2;
 mod nfx;
 pub mod record;
-mod nfx_v3;
+pub mod nfx_v3;
 
 use crate::block::{DataBlock, DataBlockHeader};
 use crate::compress::{Decompressor, NFDUMP_COMPRESSION_TYPE_BZ2, NFDUMP_COMPRESSION_TYPE_LZ4, NFDUMP_COMPRESSION_TYPE_LZO, NFDUMP_COMPRESSION_TYPE_PLAIN, NFDUMP_COMPRESSION_TYPE_ZSTD};

--- a/src/nfx_v3.rs
+++ b/src/nfx_v3.rs
@@ -3,10 +3,12 @@
 #![allow(dead_code)]
 
 use std::io::{Cursor, Read};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{Ipv4Addr, Ipv6Addr};
 use byteorder::{LittleEndian, ReadBytesExt};
 use crate::error::NfdumpError;
 use crate::record::NfFileRecordHeader;
+
+use eui48::MacAddress;
 
 const EXT_NULL: u16 = 0x0;
 const EXT_GENERIC_FLOW: u16 = 0x1;
@@ -27,6 +29,13 @@ const EXT_IN_PAYLOAD: u16 = 0x1d;
 const EXT_NSEL_X_LATE_IPV4: u16 = 0x14;
 const EXT_NSEL_X_LATE_IPV6: u16 = 0x15;
 const EXT_NSEL_X_LATE_PORT: u16 = 0x16;
+
+const EXT_MAC_ADDR: u16 = 0xf;
+const EXT_LAYER2: u16 = 0x26;
+const EXT_MPLS: u16 = 0xe;
+const EXT_TUN_V4: u16 = 0x1f;
+const EXT_TUN_V6: u16 = 0x20;
+
 
 #[derive(Debug)]
 pub struct RecordHeaderV3 {
@@ -113,18 +122,33 @@ pub struct ExNselXLatePort {
 }
 
 #[derive(Debug)]
-pub struct ExBgpNextHop {
-    pub ip: IpAddr,
+pub struct ExBgpNextHopIpv4 {
+    pub ip: Ipv4Addr,
 }
 
 #[derive(Debug)]
-pub struct ExIpNextHop {
-    pub ip: IpAddr,
+pub struct ExBgpNextHopIpv6 {
+    pub ip: Ipv6Addr,
 }
 
 #[derive(Debug)]
-pub struct ExIpReceived {
-    pub ip: IpAddr,
+pub struct ExIpNextHopIpv4 {
+    pub ip: Ipv4Addr,
+}
+
+#[derive(Debug)]
+pub struct ExIpNextHopIpv6 {
+    pub ip: Ipv6Addr,
+}
+
+#[derive(Debug)]
+pub struct ExIpReceivedIpv4 {
+    pub ip: Ipv4Addr,
+}
+
+#[derive(Debug)]
+pub struct ExIpReceivedIpv6 {
+    pub ip: Ipv6Addr,
 }
 
 pub type ExInPayload = Vec<u8>;
@@ -132,6 +156,61 @@ pub type ExInPayload = Vec<u8>;
 pub type ExNselXLateIpv4 = [u32; 10];
 
 pub type ExNselXLateIpv6 = [u128; 10];
+
+
+#[derive(Debug)]
+pub struct ExMacAddress {
+    pub in_src_mac: MacAddress,
+    pub out_dst_mac: MacAddress,
+    pub in_dst_mac: MacAddress,
+    pub out_src_mac: MacAddress,
+}
+
+#[derive(Debug)]
+pub struct ExLayer2 {
+    pub vlan_id: u16,
+    pub customer_vlan_id: u16,
+    pub post_vlan_id: u16,
+    pub post_customer_vlan_id: u16,
+    pub ingress: u32,
+    pub egress: u32,
+    pub vx_lan: u64,
+    pub ether_type: u16,
+    pub ip_version: u8,
+    pub fill: u8,
+}
+
+
+#[derive(Debug)]
+pub struct ExMPLS {
+    pub mpls_label_1:  u32,
+    pub mpls_label_2:  u32,
+    pub mpls_label_3:  u32,
+    pub mpls_label_4:  u32,
+    pub mpls_label_5:  u32,
+    pub mpls_label_6:  u32,
+    pub mpls_label_7:  u32,
+    pub mpls_label_8:  u32,
+    pub mpls_label_9:  u32,
+    pub mpls_label_10: u32,
+}
+
+
+#[derive(Debug)]
+pub struct ExTunIpv4 {
+    pub src_addr: Ipv4Addr,
+    pub dst_addr: Ipv4Addr,
+    pub proto: u8
+}
+
+
+#[derive(Debug)]
+pub struct ExTunIpv6 {
+    pub src_addr: Ipv6Addr,
+    pub dst_addr: Ipv6Addr,
+    pub proto: u8
+}
+
 
 /// `Record` represents a flow record.
 #[derive(Debug)]
@@ -146,10 +225,18 @@ pub struct RecordV3 {
     pub as_routing: Option<ExAsRouting>,
     pub sampler_info: Option<ExSamplerInfo>,
     pub nsel_xlate_port: Option<ExNselXLatePort>,
-    pub bgp_next_hop: Option<ExBgpNextHop>,
-    pub ip_next_hop: Option<ExIpNextHop>,
-    pub ip_received: Option<ExIpReceived>,
+    pub bgp_next_hop_ipv4: Option<ExBgpNextHopIpv4>,
+    pub bgp_next_hop_ipv6: Option<ExBgpNextHopIpv6>,
+    pub ip_next_hop_ipv4: Option<ExIpNextHopIpv4>,
+    pub ip_next_hop_ipv6: Option<ExIpNextHopIpv6>,
+    pub ip_received_ipv4: Option<ExIpReceivedIpv4>,
+    pub ip_received_ipv6: Option<ExIpReceivedIpv6>,
     pub in_payload: Option<ExInPayload>,
+    pub mac_address: Option<ExMacAddress>,
+    pub layer2: Option<ExLayer2>,
+    pub mpls: Option<ExMPLS>,
+    pub tun_ipv4: Option<ExTunIpv4>,
+    pub tun_ipv6: Option<ExTunIpv6>
 }
 
 impl RecordV3 {
@@ -177,137 +264,211 @@ impl RecordV3 {
             as_routing: None,
             sampler_info: None,
             nsel_xlate_port: None,
-            bgp_next_hop: None,
-            ip_next_hop: None,
-            ip_received: None,
+            bgp_next_hop_ipv4: None,
+            bgp_next_hop_ipv6: None,
+            ip_next_hop_ipv4: None,
+            ip_next_hop_ipv6: None,
+            ip_received_ipv4: None,
+            ip_received_ipv6: None,
             in_payload: None,
+            mac_address: None,
+            layer2: None,
+            mpls: None,
+            tun_ipv4: None,
+            tun_ipv6: None
         };
 
         let mut cnt = 0;
         while cnt < record.head.num_elements {
             cnt += 1;
-            let ext = cursor.read_u16::<LittleEndian>()?;
 
-            // Skip record size, it's rather redundant
-            let size = cursor.read_u16::<LittleEndian>()?;
+            // Element header
+            let ext = cursor.read_u16::<LittleEndian>()?;
+            let size = cursor.read_u16::<LittleEndian>()? as usize;
+
+            // Read extension data into a separate buffer
+            let mut ext_data = vec![0; size - 4];
+            cursor.read_exact(&mut ext_data)?;
+            let mut ext_cursor = Cursor::new(&ext_data);
 
             match ext {
                 EXT_GENERIC_FLOW => {
                     record.generic_flow = Some(ExGenericFlow {
-                        msec_first: cursor.read_u64::<LittleEndian>()?,
-                        msec_last: cursor.read_u64::<LittleEndian>()?,
-                        msec_received: cursor.read_u64::<LittleEndian>()?,
-                        in_packets: cursor.read_u64::<LittleEndian>()?,
-                        in_bytes: cursor.read_u64::<LittleEndian>()?,
-                        src_port: cursor.read_u16::<LittleEndian>()?,
-                        dst_port: cursor.read_u16::<LittleEndian>()?,
-                        proto: cursor.read_u8()?,
-                        tcp_flags: cursor.read_u8()?,
-                        fwd_status: cursor.read_u8()?,
-                        src_tos: cursor.read_u8()?,
+                        msec_first: ext_cursor.read_u64::<LittleEndian>()?,
+                        msec_last: ext_cursor.read_u64::<LittleEndian>()?,
+                        msec_received: ext_cursor.read_u64::<LittleEndian>()?,
+                        in_packets: ext_cursor.read_u64::<LittleEndian>()?,
+                        in_bytes: ext_cursor.read_u64::<LittleEndian>()?,
+                        src_port: ext_cursor.read_u16::<LittleEndian>()?,
+                        dst_port: ext_cursor.read_u16::<LittleEndian>()?,
+                        proto: ext_cursor.read_u8()?,
+                        tcp_flags: ext_cursor.read_u8()?,
+                        fwd_status: ext_cursor.read_u8()?,
+                        src_tos: ext_cursor.read_u8()?,
                     });
                 }
                 EXT_IPV4_FLOW => {
                     record.ipv4_flow = Some(ExIpv4Flow {
-                        src_addr: Ipv4Addr::from(cursor.read_u32::<LittleEndian>()?),
-                        dst_addr: Ipv4Addr::from(cursor.read_u32::<LittleEndian>()?),
+                        src_addr: Ipv4Addr::from(ext_cursor.read_u32::<LittleEndian>()?),
+                        dst_addr: Ipv4Addr::from(ext_cursor.read_u32::<LittleEndian>()?),
                     });
                 }
                 EXT_IPV6_FLOW => {
                     record.ipv6_flow = Some(ExIpv6Flow {
-                        src_addr: Ipv6Addr::from(cursor.read_u128::<LittleEndian>()?),
-                        dst_addr: Ipv6Addr::from(cursor.read_u128::<LittleEndian>()?),
+                        src_addr: Ipv6Addr::from(ext_cursor.read_u128::<LittleEndian>()?),
+                        dst_addr: Ipv6Addr::from(ext_cursor.read_u128::<LittleEndian>()?),
                     });
                 }
                 EXT_FLOW_MISC => {
                     record.flow_misc = Some(ExFlowMisc {
-                        input: cursor.read_u32::<LittleEndian>()?,
-                        output: cursor.read_u32::<LittleEndian>()?,
-                        src_mask: cursor.read_u8()?,
-                        dst_mask: cursor.read_u8()?,
-                        dir: cursor.read_u8()?,
-                        dst_tos: cursor.read_u8()?,
-                        bi_flow_dir: cursor.read_u8()?,
-                        flow_end_reason: cursor.read_u8()?,
-                        rev_tcp_flags: cursor.read_u8()?,
-                        fill: cursor.read_u8()?,
+                        input: ext_cursor.read_u32::<LittleEndian>()?,
+                        output: ext_cursor.read_u32::<LittleEndian>()?,
+                        src_mask: ext_cursor.read_u8()?,
+                        dst_mask: ext_cursor.read_u8()?,
+                        dir: ext_cursor.read_u8()?,
+                        dst_tos: ext_cursor.read_u8()?,
+                        bi_flow_dir: ext_cursor.read_u8()?,
+                        flow_end_reason: ext_cursor.read_u8()?,
+                        rev_tcp_flags: ext_cursor.read_u8()?,
+                        fill: ext_cursor.read_u8()?,
                     });
                 }
                 EXT_CNT_FLOW => {
                     record.cnt_flow = Some(ExCntFlow {
-                        flows: cursor.read_u64::<LittleEndian>()?,
-                        out_packets: cursor.read_u64::<LittleEndian>()?,
-                        out_bytes: cursor.read_u64::<LittleEndian>()?,
+                        flows: ext_cursor.read_u64::<LittleEndian>()?,
+                        out_packets: ext_cursor.read_u64::<LittleEndian>()?,
+                        out_bytes: ext_cursor.read_u64::<LittleEndian>()?,
                     });
                 }
                 EXT_VLAN_FLOW => {
                     record.vlan = Some(ExVlan {
-                        src_vlan: cursor.read_u32::<LittleEndian>()?,
-                        dst_vlan: cursor.read_u32::<LittleEndian>()?,
+                        src_vlan: ext_cursor.read_u32::<LittleEndian>()?,
+                        dst_vlan: ext_cursor.read_u32::<LittleEndian>()?,
                     });
                 }
                 EXT_AS_ROUTING => {
                     record.as_routing = Some(ExAsRouting {
-                        src_as: cursor.read_u32::<LittleEndian>()?,
-                        dst_as: cursor.read_u32::<LittleEndian>()?,
+                        src_as: ext_cursor.read_u32::<LittleEndian>()?,
+                        dst_as: ext_cursor.read_u32::<LittleEndian>()?,
                     });
                 }
                 EXT_SAMPLER_INFO => {
                     record.sampler_info = Some(ExSamplerInfo {
-                        selector_id: cursor.read_u64::<LittleEndian>()?,
-                        sysid: cursor.read_u16::<LittleEndian>()?,
-                        align: cursor.read_u16::<LittleEndian>()?,
+                        selector_id: ext_cursor.read_u64::<LittleEndian>()?,
+                        sysid: ext_cursor.read_u16::<LittleEndian>()?,
+                        align: ext_cursor.read_u16::<LittleEndian>()?,
                     });
                 }
                 EXT_NSEL_X_LATE_PORT => {
                     record.nsel_xlate_port = Some(ExNselXLatePort {
-                        src_port: cursor.read_u16::<LittleEndian>()?,
-                        dst_port: cursor.read_u16::<LittleEndian>()?,
+                        src_port: ext_cursor.read_u16::<LittleEndian>()?,
+                        dst_port: ext_cursor.read_u16::<LittleEndian>()?,
                     });
                 }
                 EXT_BGP_NEXT_HOP_V4 => {
-                    record.bgp_next_hop = Some(ExBgpNextHop {
-                        ip: IpAddr::from(Ipv4Addr::from(cursor.read_u32::<LittleEndian>()?)),
+                    record.bgp_next_hop_ipv4 = Some(ExBgpNextHopIpv4 {
+                        ip: Ipv4Addr::from(ext_cursor.read_u32::<LittleEndian>()?),
                     });
                 }
                 EXT_BGP_NEXT_HOP_V6 => {
-                    record.bgp_next_hop = Some(ExBgpNextHop {
-                        ip: IpAddr::from(Ipv6Addr::from(cursor.read_u128::<LittleEndian>()?)),
+                    record.bgp_next_hop_ipv6 = Some(ExBgpNextHopIpv6 {
+                        ip: Ipv6Addr::from(ext_cursor.read_u128::<LittleEndian>()?),
                     });
                 }
                 EXT_IP_NEXT_HOP_V4 => {
-                    record.ip_next_hop = Some(ExIpNextHop {
-                        ip: IpAddr::from(Ipv4Addr::from(cursor.read_u32::<LittleEndian>()?)),
+                    record.ip_next_hop_ipv4 = Some(ExIpNextHopIpv4 {
+                        ip: Ipv4Addr::from(ext_cursor.read_u32::<LittleEndian>()?),
                     });
                 }
                 EXT_IP_NEXT_HOP_V6 => {
-                    record.ip_next_hop = Some(ExIpNextHop {
-                        ip: IpAddr::from(Ipv6Addr::from(cursor.read_u128::<LittleEndian>()?)),
+                    record.ip_next_hop_ipv6 = Some(ExIpNextHopIpv6 {
+                        ip: Ipv6Addr::from(ext_cursor.read_u128::<LittleEndian>()?),
                     });
                 }
                 EXT_IP_RECEIVED_V4 => {
-                    record.ip_received = Some(ExIpReceived {
-                        ip: IpAddr::from(Ipv4Addr::from(cursor.read_u32::<LittleEndian>()?)),
+                    record.ip_received_ipv4 = Some(ExIpReceivedIpv4 {
+                        ip: Ipv4Addr::from(ext_cursor.read_u32::<LittleEndian>()?)
                     });
                 }
                 EXT_IP_RECEIVED_V6 => {
-                    record.ip_received = Some(ExIpReceived {
-                        ip: IpAddr::from(Ipv6Addr::from(cursor.read_u128::<LittleEndian>()?)),
+                    record.ip_received_ipv6 = Some(ExIpReceivedIpv6 {
+                        ip: Ipv6Addr::from(ext_cursor.read_u128::<LittleEndian>()?)
                     });
                 }
                 EXT_IN_PAYLOAD => {
                     let mut payload = vec![0; record.head.header.size as usize - 4];
-                    cursor.read_exact(&mut payload)?;
+                    ext_cursor.read_exact(&mut payload)?;
                     record.in_payload = Some(payload);
                 }
-                _ => {
-                    // Skip unimplemented extensions
-                    let mut buf = vec![0; size as usize - 4];
-                    cursor.read_exact(&mut buf)?;
+                EXT_MAC_ADDR => {
+                    record.mac_address = Some(ExMacAddress {
+                        in_src_mac: _mac_from_u64(ext_cursor.read_u64::<LittleEndian>()?),
+                        out_dst_mac: _mac_from_u64(ext_cursor.read_u64::<LittleEndian>()?),
+                        in_dst_mac: _mac_from_u64(ext_cursor.read_u64::<LittleEndian>()?),
+                        out_src_mac: _mac_from_u64(ext_cursor.read_u64::<LittleEndian>()?),
+                    });
                 }
+                EXT_LAYER2 => {
+                    record.layer2 = Some(ExLayer2 {
+                        vlan_id: ext_cursor.read_u16::<LittleEndian>()?,
+                        customer_vlan_id: ext_cursor.read_u16::<LittleEndian>()?,
+                        post_vlan_id: ext_cursor.read_u16::<LittleEndian>()?,
+                        post_customer_vlan_id: ext_cursor.read_u16::<LittleEndian>()?,
+                        ingress: ext_cursor.read_u32::<LittleEndian>()?,
+                        egress: ext_cursor.read_u32::<LittleEndian>()?,
+                        vx_lan: ext_cursor.read_u64::<LittleEndian>()?,
+                        ether_type: ext_cursor.read_u16::<LittleEndian>()?,
+                        ip_version: ext_cursor.read_u8()?,
+                        fill: ext_cursor.read_u8()?,
+                    });
+                }
+                EXT_MPLS => {
+                    record.mpls = Some(ExMPLS {
+                        mpls_label_1:  ext_cursor.read_u32::<LittleEndian>()?,
+                        mpls_label_2:  ext_cursor.read_u32::<LittleEndian>()?,
+                        mpls_label_3:  ext_cursor.read_u32::<LittleEndian>()?,
+                        mpls_label_4:  ext_cursor.read_u32::<LittleEndian>()?,
+                        mpls_label_5:  ext_cursor.read_u32::<LittleEndian>()?,
+                        mpls_label_6:  ext_cursor.read_u32::<LittleEndian>()?,
+                        mpls_label_7:  ext_cursor.read_u32::<LittleEndian>()?,
+                        mpls_label_8:  ext_cursor.read_u32::<LittleEndian>()?,
+                        mpls_label_9:  ext_cursor.read_u32::<LittleEndian>()?,
+                        mpls_label_10: ext_cursor.read_u32::<LittleEndian>()?,
+                    });
+                }
+                EXT_TUN_V4 => {
+                    record.tun_ipv4 = Some(ExTunIpv4 {
+                        src_addr: Ipv4Addr::from(ext_cursor.read_u32::<LittleEndian>()?),
+                        dst_addr: Ipv4Addr::from(ext_cursor.read_u32::<LittleEndian>()?),
+                        proto: ext_cursor.read_u8()?,
+                    });
+                }
+                EXT_TUN_V6 => {
+                    record.tun_ipv6 = Some(ExTunIpv6 {
+                        src_addr: Ipv6Addr::from(ext_cursor.read_u128::<LittleEndian>()?),
+                        dst_addr: Ipv6Addr::from(ext_cursor.read_u128::<LittleEndian>()?),
+                        proto: ext_cursor.read_u8()?,
+                    });
+                }
+                _ => {}
             }
+
         }
 
         return Ok(record);
     }
+}
+
+
+fn _mac_from_u64(value: u64) -> MacAddress {
+    let bytes = [
+        (value >> 40 & 0xFF) as u8,
+        (value >> 32 & 0xFF) as u8,
+        (value >> 24 & 0xFF) as u8,
+        (value >> 16 & 0xFF) as u8,
+        (value >> 8  & 0xFF) as u8,
+        (value       & 0xFF) as u8,
+    ];
+
+    MacAddress::new(bytes)
 }


### PR DESCRIPTION
Hi Mark

Many thanks for your work on the nfdump integration for Rust, which is very useful to us!

With this pull request, I propose a slight modification of the extension parsing for nfx V3 files, newly including the following extension types:
- `EXT_MAC_ADDR` (MAC Addresses)
- `EXT_LAYER2` (Further layer2 information, e.g., for VLANs)
- `EXT_MPLS` (MPLS Label Stack)
- `EXT_TUN_V4` / `EXT_TUN_V6` (Extensions keeping information from outer IP header for tunneled packets)

Moreover, it would be useful to collect both IPv4 _and_ IPv6 information for some extensions that were already implementend, namely ` EXT_BGP_NEXT_HOP_V4|V6`, `EXT_IP_NEXT_HOP_V4|V6`, and `EXT_IP_RECEIVED_V4|V6`.

Let me know what you think!

Best regards,
Simon from [NetFabric.ai](https://netfabric.ai/)